### PR TITLE
remove pragma "blasint = ..."

### DIFF
--- a/source/cblas/cblas.di
+++ b/source/cblas/cblas.di
@@ -43,8 +43,6 @@ else
 	///
 	alias blasint = int;
 
-debug pragma(msg, "blasint = " ~ blasint.stringof);
-
 ///
 enum CBLAS_LAYOUT {
 	///


### PR DESCRIPTION
The message `blasint = int` pollutes a lot of the debug builds which uses cblas as a library.
